### PR TITLE
Add point size visualization and frequency filtering

### DIFF
--- a/tristogram/README.md
+++ b/tristogram/README.md
@@ -5,10 +5,14 @@ A 3D color histogram visualization tool built with React Three Fiber that create
 ## Features
 
 - **3D Color Space Visualization**: Displays colors as points in a 3D RGB cube (256x256x256)
+- **Dual Visualization Modes**: 
+  - **Opacity Mode**: Point transparency represents color frequency
+  - **Point Size Mode**: Variable point sizes represent color frequency using custom shaders
+- **Advanced Frequency Filtering**: Bidirectional min/max threshold sliders to reduce visual occlusion
 - **React Three Fiber Integration**: Modern React declarative 3D scene composition
 - **Interactive Controls**: Rotate, zoom, and pan around the color histogram using OrbitControls
 - **Multiple Image Support**: Built-in gallery of test images plus drag-and-drop support
-- **Real-time Adjustments**: Modify point size and background color using Leva GUI controls
+- **Real-time Adjustments**: Dynamic control over visualization mode, point scaling, frequency filtering, and background color
 - **Source Image Display**: Shows the original image alongside the 3D histogram
 - **Component-based Architecture**: Clean React components with proper state management
 
@@ -20,7 +24,24 @@ The tristogram analyzes each pixel in an image and maps it to a 3D coordinate sy
 - Y-axis represents Green values (0-255) 
 - Z-axis represents Blue values (0-255)
 
-Each point's opacity corresponds to how frequently that color appears in the image.
+Each point's visual representation corresponds to how frequently that color appears in the image:
+
+- **Opacity Mode**: More frequent colors appear more opaque, less frequent colors are more transparent
+- **Point Size Mode**: More frequent colors appear as larger points, less frequent colors as smaller points
+
+## Frequency Filtering
+
+The application includes advanced filtering capabilities to reduce visual occlusion and focus on specific color frequency ranges:
+
+- **Min Frequency Threshold**: Hide colors that appear less frequently than this threshold (0.0 = show all, 1.0 = show only the most frequent)
+- **Max Frequency Threshold**: Hide colors that appear more frequently than this threshold (1.0 = show all, 0.0 = hide all)
+
+### Filtering Examples
+
+- **Focus on rare colors**: Set Max Frequency to 0.3 to hide dominant colors and reveal rare ones
+- **Focus on common colors**: Set Min Frequency to 0.7 to show only very frequent colors
+- **Mid-range window**: Set Min: 0.2, Max: 0.6 to show colors of moderate frequency
+- **Remove noise**: Set Min Frequency > 0.0 to filter out single-pixel artifacts
 
 ## Pixel Source Tracking
 
@@ -255,7 +276,12 @@ The benchmarks show that:
 
 - **Mouse**: Orbit around the visualization (via OrbitControls)
 - **Scroll**: Zoom in/out
-- **Leva GUI Panel**: Change images, adjust point size, and background color
+- **Leva GUI Panel**: 
+  - **Image Selection**: Choose from built-in gallery of test images
+  - **Visualization Mode**: Switch between opacity and point size modes
+  - **Point Size**: Scale factor for point sizes (base size in opacity mode, multiplier in size mode)
+  - **Min/Max Frequency**: Bidirectional filtering to show/hide colors based on frequency thresholds
+  - **Background**: Adjust background color for better contrast
 - **Drag & Drop**: Drop image files directly onto the canvas to analyze new images
 
 ## Dependencies

--- a/tristogram/src/App.tsx
+++ b/tristogram/src/App.tsx
@@ -40,21 +40,21 @@ function TristogramVisualization({ droppedImageUrl }: TristogramVisualizationPro
     maxThreshold
   } = useControls({
     image: {
-      value: '/images/wallaby_746_600x450.jpg',
+      value: './images/wallaby_746_600x450.jpg',
       options: {
-        glitchGray: '/images/glitch-art-phone-gray.jpg',
-        glitchRed: '/images/glitch-art-phone-r.jpg',
-        glitchRB: '/images/glitch-art-phone-rb.jpg',
-        glitchRGB: '/images/glitch-art-phone-rbg.jpg',
-        glitchR: '/images/glitch-art-phone-red.jpg',
-        godberGlitch: '/images/godber-glitch.jpg',
-        godber: '/images/godber.jpg',
-        rainbow: '/images/rainbow.png',
-        gray: '/images/grayscale.png',
-        blue: '/images/blue-black-gradient.png',
-        green: '/images/green-black-gradient.png',
-        red: '/images/red-black-gradient.png',
-        wallaby: '/images/wallaby_746_600x450.jpg',
+        glitchGray: './images/glitch-art-phone-gray.jpg',
+        glitchRed: './images/glitch-art-phone-r.jpg',
+        glitchRB: './images/glitch-art-phone-rb.jpg',
+        glitchRGB: './images/glitch-art-phone-rbg.jpg',
+        glitchR: './images/glitch-art-phone-red.jpg',
+        godberGlitch: './images/godber-glitch.jpg',
+        godber: './images/godber.jpg',
+        rainbow: './images/rainbow.png',
+        gray: './images/grayscale.png',
+        blue: './images/blue-black-gradient.png',
+        green: './images/green-black-gradient.png',
+        red: './images/red-black-gradient.png',
+        wallaby: './images/wallaby_746_600x450.jpg',
       }
     },
     visualizationMode: {

--- a/tristogram/src/App.tsx
+++ b/tristogram/src/App.tsx
@@ -12,6 +12,7 @@ interface TristogramVisualizationProps {
 interface ImageData {
   positions: Float32Array;
   colors: Float32Array;
+  sizes: Float32Array;
 }
 
 extend({ OrbitControls });
@@ -28,11 +29,15 @@ function TristogramVisualization({ droppedImageUrl }: TristogramVisualizationPro
   
   const [imageData, setImageData] = useState<ImageData | null>(null);
   const [imageTexture, setImageTexture] = useState<THREE.Texture | null>(null);
+  const [tristogramInstance, setTristogramInstance] = useState<Tristogram | null>(null);
 
   const { 
     image, 
     pointSize, 
-    background 
+    background,
+    visualizationMode,
+    minThreshold,
+    maxThreshold
   } = useControls({
     image: {
       value: '/images/wallaby_746_600x450.jpg',
@@ -52,13 +57,29 @@ function TristogramVisualization({ droppedImageUrl }: TristogramVisualizationPro
         wallaby: '/images/wallaby_746_600x450.jpg',
       }
     },
+    visualizationMode: {
+      value: 'opacity',
+      options: {
+        'Opacity': 'opacity',
+        'Point Size': 'size'
+      }
+    },
     pointSize: { value: 1, min: 1, max: 20, step: 1 },
+    minThreshold: { value: 0.0, min: 0.0, max: 1.0, step: 0.01, label: 'Min Frequency' },
+    maxThreshold: { value: 1.0, min: 0.0, max: 1.0, step: 0.01, label: 'Max Frequency' },
     background: '#111111'
   });
 
   React.useEffect(() => {
     scene.background = new THREE.Color(background);
   }, [background, scene]);
+
+  // Update shader uniform when pointSize changes
+  React.useEffect(() => {
+    if (pointsRef.current && pointsRef.current.material instanceof THREE.ShaderMaterial) {
+      pointsRef.current.material.uniforms.sizeScale.value = pointSize;
+    }
+  }, [pointSize]);
 
   const currentImageUrl = droppedImageUrl || image;
 
@@ -67,8 +88,10 @@ function TristogramVisualization({ droppedImageUrl }: TristogramVisualizationPro
     loader.load(
       currentImageUrl,
       (texture) => {
-        const tristogram = Tristogram.fromHTMLImage(texture.image);
-        setImageData(tristogram);
+        const tristogram = Tristogram.fromHTMLImage(texture.image, { 
+          visualizationMode: visualizationMode as 'opacity' | 'size' 
+        });
+        setTristogramInstance(tristogram);
         setImageTexture(texture);
       },
       undefined,
@@ -76,7 +99,18 @@ function TristogramVisualization({ droppedImageUrl }: TristogramVisualizationPro
         console.error('Error loading image:', error);
       }
     );
-  }, [currentImageUrl]);
+  }, [currentImageUrl, visualizationMode]);
+
+  // Update filtered data when thresholds change
+  React.useEffect(() => {
+    if (tristogramInstance) {
+      // Ensure min <= max
+      const min = Math.min(minThreshold, maxThreshold);
+      const max = Math.max(minThreshold, maxThreshold);
+      const filteredData = tristogramInstance.getFilteredData(min, max);
+      setImageData(filteredData);
+    }
+  }, [tristogramInstance, minThreshold, maxThreshold]);
 
   const pointsGeometry = useMemo((): THREE.BufferGeometry | null => {
     if (!imageData) return null;
@@ -84,17 +118,55 @@ function TristogramVisualization({ droppedImageUrl }: TristogramVisualizationPro
     const geometry = new THREE.BufferGeometry();
     geometry.setAttribute('position', new THREE.Float32BufferAttribute(imageData.positions, 3));
     geometry.setAttribute('color', new THREE.Float32BufferAttribute(imageData.colors, 4));
+    
+    // Add size attribute for variable point sizes
+    if (visualizationMode === 'size') {
+      geometry.setAttribute('size', new THREE.Float32BufferAttribute(imageData.sizes, 1));
+    }
+    
     return geometry;
-  }, [imageData]);
+  }, [imageData, visualizationMode]);
 
-  const pointsMaterial = useMemo((): THREE.PointsMaterial => {
-    return new THREE.PointsMaterial({
-      size: pointSize,
-      vertexColors: true,
-      transparent: true,
-      sizeAttenuation: true,
-    });
-  }, [pointSize]);
+  const pointsMaterial = useMemo((): THREE.PointsMaterial | THREE.ShaderMaterial => {
+    if (visualizationMode === 'size') {
+      // Custom shader material for variable point sizes
+      return new THREE.ShaderMaterial({
+        uniforms: {
+          sizeScale: { value: pointSize }
+        },
+        vertexShader: `
+          uniform float sizeScale;
+          attribute float size;
+          attribute vec4 color;
+          varying vec4 vColor;
+          
+          void main() {
+            vColor = color;
+            vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+            gl_PointSize = size * sizeScale;
+            gl_Position = projectionMatrix * mvPosition;
+          }
+        `,
+        fragmentShader: `
+          varying vec4 vColor;
+          
+          void main() {
+            vec2 center = gl_PointCoord - vec2(0.5);
+            if (length(center) > 0.5) discard;
+            gl_FragColor = vColor;
+          }
+        `,
+        transparent: true,
+      });
+    } else {
+      return new THREE.PointsMaterial({
+        size: pointSize,
+        vertexColors: true,
+        transparent: true,
+        sizeAttenuation: true,
+      });
+    }
+  }, [pointSize, visualizationMode]);
 
   const imageGeometry = useMemo((): THREE.PlaneGeometry | null => {
     if (!imageTexture) return null;

--- a/tristogram/src/__tests__/App.test.tsx
+++ b/tristogram/src/__tests__/App.test.tsx
@@ -42,7 +42,7 @@ vi.mock('@react-three/drei', () => ({
 // Mock Leva
 vi.mock('leva', () => ({
   useControls: () => ({
-    image: '/images/wallaby_746_600x450.jpg',
+    image: './images/wallaby_746_600x450.jpg',
     pointSize: 1,
     background: '#111111',
   }),

--- a/tristogram/src/main.ts
+++ b/tristogram/src/main.ts
@@ -21,7 +21,7 @@ interface GuiSettings {
 }
 
 const guiSettings: GuiSettings = {
-  image: '/images/wallaby_746_600x450.jpg',
+  image: './images/wallaby_746_600x450.jpg',
   background: 0x111111,
   pointSize: 1,
 };
@@ -36,19 +36,19 @@ animate();
 function guiInit(): void {
   const gui = new GUI();
   gui.add(guiSettings, 'image', {
-    glitchGray: '/images/glitch-art-phone-gray.jpg',
-    glitchRed: '/images/glitch-art-phone-r.jpg',
-    glitchRB: '/images/glitch-art-phone-rb.jpg',
-    glitchRGB: '/images/glitch-art-phone-rbg.jpg',
-    glitchR: '/images/glitch-art-phone-red.jpg',
-    godberGlitch: '/images/godber-glitch.jpg',
-    godber: '/images/godber.jpg',
-    rainbow: '/images/rainbow.png',
-    gray: '/images/grayscale.png',
-    blue: '/images/blue-black-gradient.png',
-    green: '/images/green-black-gradient.png',
-    red: '/images/red-black-gradient.png',
-    wallaby: '/images/wallaby_746_600x450.jpg',
+    glitchGray: './images/glitch-art-phone-gray.jpg',
+    glitchRed: './images/glitch-art-phone-r.jpg',
+    glitchRB: './images/glitch-art-phone-rb.jpg',
+    glitchRGB: './images/glitch-art-phone-rbg.jpg',
+    glitchR: './images/glitch-art-phone-red.jpg',
+    godberGlitch: './images/godber-glitch.jpg',
+    godber: './images/godber.jpg',
+    rainbow: './images/rainbow.png',
+    gray: './images/grayscale.png',
+    blue: './images/blue-black-gradient.png',
+    green: './images/green-black-gradient.png',
+    red: './images/red-black-gradient.png',
+    wallaby: './images/wallaby_746_600x450.jpg',
   }).name('Image');
   gui.add(guiSettings, 'pointSize', 1, 20, 1).name('Point Size');
   gui.addColor(guiSettings, 'background').name('Background');

--- a/tristogram/vite.config.ts
+++ b/tristogram/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  base: './',
   root: '.',
   publicDir: 'public',
   server: {


### PR DESCRIPTION
## Summary
- Add new visualization mode dropdown with opacity/size options
- Implement variable point sizes based on color frequency using custom shader material
- Add bidirectional frequency filtering with min/max threshold sliders to reduce occlusion

## Test plan
- [ ] Test point size visualization mode shows variable sized points
- [ ] Verify point size slider acts as scale factor in size mode  
- [ ] Test frequency filtering reduces visual clutter
- [ ] Confirm min/max threshold sliders work independently
- [ ] Test with different images to verify functionality

🤖 Generated with [Claude Code](https://claude.ai/code)